### PR TITLE
Make postcodes optional

### DIFF
--- a/app/uk/gov/hmrc/eeitt/models/EnrollmentDetails.scala
+++ b/app/uk/gov/hmrc/eeitt/models/EnrollmentDetails.scala
@@ -21,7 +21,7 @@ import play.api.data.Forms._
 import play.api.libs.json.Json
 
 case class EnrollmentDetails(registrationNumber: String,
-                             postcode: String,
+                             postcode: Option[String],
                              groupId: String)
 
 object EnrollmentDetails {
@@ -29,13 +29,13 @@ object EnrollmentDetails {
 
   val form = Form(mapping(
     "registrationNumber" -> text,
-    "postcode" -> text,
+    "postcode" -> optional(text),
     "groupId" -> text
   )(EnrollmentDetails.apply)(EnrollmentDetails.unapply))
 }
 
 case class AgentEnrollmentDetails(arn: String,
-                                  postcode: String,
+                                  postcode: Option[String],
                                   groupId: String)
 
 object AgentEnrollmentDetails {
@@ -43,7 +43,7 @@ object AgentEnrollmentDetails {
 
   val form = Form(mapping(
     "arn" -> text,
-    "postcode" -> text,
+    "postcode" -> optional(text),
     "groupId" -> text
   )(AgentEnrollmentDetails.apply)(AgentEnrollmentDetails.unapply))
 }

--- a/app/uk/gov/hmrc/eeitt/testonly/SignOutController.scala
+++ b/app/uk/gov/hmrc/eeitt/testonly/SignOutController.scala
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.eeitt.controllers
+package uk.gov.hmrc.eeitt.testonly
 
 import play.api.mvc.{Action, Controller}
 import play.twirl.api.Html
+import uk.gov.hmrc.eeitt.controllers.routes.EnrollmentVerificationController.displayVerificationPage
 
 object SignOutController extends Controller {
   def signOut = Action { request =>
     Ok(
       Html(
-        """
-         <p>Signed-out, thanks for doing business with HMRC!<p>
-
-         <a href="/eeitt-frontend/enrollment-verification?callbackUrl=bar">Try again</a>
+        s"""
+         <a href=${displayVerificationPage("http://bbc.co.uk")}>Try again</a>
         """
       )
     ).withNewSession

--- a/app/uk/gov/hmrc/eeitt/views/login_status.scala.html
+++ b/app/uk/gov/hmrc/eeitt/views/login_status.scala.html
@@ -24,7 +24,6 @@
         agentOrUserDisplayName
       )
     }
-    <br><a id="logOutStatusHref" href="@uk.gov.hmrc.eeitt.controllers.routes.SignOutController.signOut().url">Sign out (should we allow??)</a>
   </p>
 
 </div>

--- a/app/uk/gov/hmrc/eeitt/views/verification_agent.scala.html
+++ b/app/uk/gov/hmrc/eeitt/views/verification_agent.scala.html
@@ -55,7 +55,6 @@
           id="postcode"
           value="@enrollmentForm("postcode").value"
           class="form-control form-control--block"
-          required
           data-msg-required="Please enter a postcode."
         >
       </label>

--- a/app/uk/gov/hmrc/eeitt/views/verification_non_agent.scala.html
+++ b/app/uk/gov/hmrc/eeitt/views/verification_non_agent.scala.html
@@ -57,7 +57,6 @@
         id="postcode"
         value="@enrollmentForm("postcode").value"
         class="form-control form-control--block"
-        required
         data-msg-required="Please enter a postcode."
         >
       </label>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,5 +3,3 @@
 GET     /enrollment-verification            uk.gov.hmrc.eeitt.controllers.EnrollmentVerificationController.displayVerificationPage(callbackUrl)
 POST    /enrollment-verification            uk.gov.hmrc.eeitt.controllers.EnrollmentVerificationController.submitEnrollmentDetails(callbackUrl)
 POST    /enrollment-agent-verification      uk.gov.hmrc.eeitt.controllers.EnrollmentVerificationController.submitAgentEnrollmentDetails(callbackUrl)
-
-GET     /sign-out                           uk.gov.hmrc.eeitt.controllers.SignOutController.signOut()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,6 +11,7 @@
 
 POST       /eeitt-auth/test-only/etmp-data/business-users             uk.gov.hmrc.eeitt.testonly.EtmpDataLoaderProxy.loadBusinessUsers
 POST       /eeitt-auth/test-only/etmp-data/agents                     uk.gov.hmrc.eeitt.testonly.EtmpDataLoaderProxy.loadAgents
+GET        /eeitt-auth/test-only/sign-out                            uk.gov.hmrc.eeitt.testonly.SignOutController.signOut()
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes


### PR DESCRIPTION
I made postcodes optional as people from outside of the UK will not have them (at least in ETMP db). Also since we didn't get content guidelines on the sign-out page I removed a link to sign-out and moved the sign-out controller to a test-only area so it can still be used by us for convenience (by `hitting /eeitt-auth/test-only/sign-out` directly) but users in prod will not be able to use it.